### PR TITLE
Added an account screen when creating the xDai network on Metamask

### DIFF
--- a/src/assets/xdai-logo.svg
+++ b/src/assets/xdai-logo.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Icons/Tokens/xDai</title>
+    <g id="Icons/Tokens/xDai" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Group">
+            <circle id="Oval" fill="#62A7A5" cx="20" cy="20" r="20"></circle>
+            <path d="M18,8 L8,8 L8,13 L18,13 L18,8 Z M32,8 L22,8 L22,13 L32,13 L32,8 Z M22,27 L27,27 L27,22 L32,22 L32,27 L32,32 L27,32 L22,32 L22,27 Z M18,27 L13,27 L13,22 L8,22 L8,27 L8,32 L13,32 L18,32 L18,27 Z" id="Shape" fill="#FFFFFF"></path>
+        </g>
+    </g>
+</svg>

--- a/src/components/Account/ScreenPromptingAction.js
+++ b/src/components/Account/ScreenPromptingAction.js
@@ -3,11 +3,6 @@ import PropTypes from 'prop-types'
 import { keyframes } from 'styled-components'
 import { GU, useTheme, textStyle, Link } from '@commonsswarm/ui'
 
-import {
-  getProviderFromUseWalletId,
-  getProviderString,
-} from '../../ethereum-providers'
-
 import loadingRing from './assets/loading-ring.svg'
 
 const spin = keyframes`
@@ -19,12 +14,13 @@ const spin = keyframes`
   }
 `
 
-const AccountModuleConnectingScreen = React.memo(function({
+const AccountModuleActionScreen = React.memo(function({
   onCancel,
-  providerId,
+  actionTitle,
+  actionDescription,
+  logo,
 }) {
   const theme = useTheme()
-  const provider = getProviderFromUseWalletId(providerId)
   return (
     <section
       css={`
@@ -76,8 +72,7 @@ const AccountModuleConnectingScreen = React.memo(function({
               left: 0;
               right: 0;
               bottom: 0;
-              background: 50% 50% / auto ${5 * GU}px no-repeat
-                url(${provider.image});
+              background: 50% 50% / auto ${5 * GU}px no-repeat url(${logo});
             `}
           />
         </div>
@@ -88,7 +83,7 @@ const AccountModuleConnectingScreen = React.memo(function({
             font-weight: 600;
           `}
         >
-          Connecting to {provider.name}
+          {actionTitle}
         </h1>
         <p
           css={`
@@ -96,8 +91,7 @@ const AccountModuleConnectingScreen = React.memo(function({
             color: ${theme.surfaceContentSecondary};
           `}
         >
-          Log into {getProviderString('your Ethereum provider', provider.id)}.
-          You may be temporarily redirected to a new screen.
+          {actionDescription}
         </p>
       </div>
       <div
@@ -105,15 +99,17 @@ const AccountModuleConnectingScreen = React.memo(function({
           flex-grow: 0;
         `}
       >
-        <Link onClick={onCancel}>Cancel</Link>
+        {onCancel && <Link onClick={onCancel}>Cancel</Link>}
       </div>
     </section>
   )
 })
 
-AccountModuleConnectingScreen.propTypes = {
-  providerId: PropTypes.string,
-  onCancel: PropTypes.func.isRequired,
+AccountModuleActionScreen.propTypes = {
+  actionTitle: PropTypes.string,
+  actionDescription: PropTypes.string,
+  logo: PropTypes.string,
+  onCancel: PropTypes.func,
 }
 
-export default AccountModuleConnectingScreen
+export default AccountModuleActionScreen

--- a/src/networks.js
+++ b/src/networks.js
@@ -1,3 +1,5 @@
+import xDaiLogo from './assets/xdai-logo.svg'
+
 const ORG_ADDRESS = process.env.REACT_APP_ORG_ADDRESS.toLowerCase()
 const CONNECTOR_TYPE = process.env.REACT_APP_CONNECTOR_TYPE
 const CHAIN_ID = process.env.REACT_APP_CHAIN_ID
@@ -25,6 +27,7 @@ const networks = {
     ensRegistry: '0xaafca6b0c89521752e559650206d7c925fd0e530',
     name: 'xDai',
     type: 'xdai',
+    image: xDaiLogo,
     defaultEthNode: 'https://xdai.1hive.org/',
     org: { address: ORG_ADDRESS, connectorType: CONNECTOR_TYPE },
     ipfsGateway: 'https://ipfs.eth.aragon.network/ipfs',


### PR DESCRIPTION
Transformed the "ScreenConnecting" screen into a module that shows up with xDai logo and custom text when the user is required to allow creating the xDai network and switching to it.

![Captura de pantalla 2021-05-28 a las 16 07 40](https://user-images.githubusercontent.com/78225502/119996639-3b5cb900-bfcf-11eb-974e-639c74dd2f33.png)
